### PR TITLE
V2NodeViewController的menu一些修改

### DIFF
--- a/v2ex-iOS/Controllers/V2NodeViewController.m
+++ b/v2ex-iOS/Controllers/V2NodeViewController.m
@@ -131,7 +131,12 @@
     self.addBarItem = [[SCBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"navi_add"] style:SCBarButtonItemStylePlain handler:^(id sender) {
         @strongify(self);
         
-        [self showMenuAnimated:YES];
+        if (self.isMenuShowing) {
+            [self hideMenuAnimated:YES];
+        }
+        else {
+            [self showMenuAnimated:YES];
+        }
         
     }];
 

--- a/v2ex-iOS/Controllers/V2NodeViewController.m
+++ b/v2ex-iOS/Controllers/V2NodeViewController.m
@@ -161,6 +161,13 @@
     
     self.menuBackgroundButton = [UIButton buttonWithType:UIButtonTypeCustom];
     self.menuBackgroundButton.backgroundColor = [UIColor colorWithWhite:0.667 alpha:0];
+    
+    @weakify(self)
+    UIPanGestureRecognizer *menuBGButtonPanGesture = [UIPanGestureRecognizer bk_recognizerWithHandler:^(UIGestureRecognizer *sender, UIGestureRecognizerState state, CGPoint location) {
+        @strongify(self)
+        [self hideMenuAnimated:NO];
+    }];
+    [self.menuBackgroundButton addGestureRecognizer:menuBGButtonPanGesture];
     [self.menuContainView addSubview:self.menuBackgroundButton];
     
     self.menuView = [[UIView alloc] init];
@@ -184,7 +191,6 @@
     NSArray *itemTitleArray = @[@"发帖", @"收藏"];
     NSArray *itemImageArray = @[@"icon_post", @"icon_fav"];
     
-    @weakify(self);
     void (^buttonHandleBlock)(NSInteger index) = ^(NSInteger index) {
         @strongify(self);
         


### PR DESCRIPTION
fix: V2NoteVC右上角的+，在打开情况下，再点击无效，感觉从体验角度上，打开+的时候再点击是关闭
feat: V2NodeViewController页面的加号点击出来的menuView，之前滑动是会直接相应滑动，参考了微信那边的滑动第一响应还是关闭menu，做了一个动作。