### PR TITLE
Fix weibo share fail with null token and add weibo's query schemes

### DIFF
--- a/v2ex-iOS.xcodeproj/project.pbxproj
+++ b/v2ex-iOS.xcodeproj/project.pbxproj
@@ -1214,10 +1214,10 @@
 				ORGANIZATIONNAME = Singro;
 				TargetAttributes = {
 					2933868618D67B6B00FEC28E = {
-						DevelopmentTeam = 8KZ3G3A2FQ;
+						DevelopmentTeam = 7FD57FD92A;
 					};
 					29C0BDB21BA3A89E007B110C = {
-						DevelopmentTeam = 8KZ3G3A2FQ;
+						DevelopmentTeam = 7FD57FD92A;
 					};
 				};
 			};

--- a/v2ex-iOS/Additions/SCWeiboManager/SCWeiboManager.m
+++ b/v2ex-iOS/Additions/SCWeiboManager/SCWeiboManager.m
@@ -40,7 +40,7 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
         manager = [[SCWeiboManager alloc] init];
         
         [WeiboSDK registerApp:kWeiboAppKey];
-
+        
         manager.token = [[FXKeychain defaultKeychain] objectForKey:kWeiboToken];
         manager.expirationDate = [[FXKeychain defaultKeychain] objectForKey:kWeiboExpirationDate];
         
@@ -73,7 +73,7 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
 }
 
 - (void)clean {
-
+    
     [[FXKeychain defaultKeychain] removeObjectForKey:kWeiboToken];
     [[FXKeychain defaultKeychain] removeObjectForKey:kWeiboExpirationDate];
     _token = nil;
@@ -97,6 +97,15 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
         [paras setObject:obj forKey:key];
     }];
     
+    if (self.isExpired) {
+        [self authorizeToWeiboSuccess:^(WBBaseResponse *response) {
+            self.token = [(WBAuthorizeResponse *)response accessToken];
+            self.expirationDate = [(WBAuthorizeResponse *)response expirationDate];
+        } failure:^(NSError *error) {
+            //
+        }];
+    }
+    
     WBHttpRequest *request = [WBHttpRequest requestWithAccessToken:self.token
                                                                url:urlString
                                                         httpMethod:httpMethod
@@ -108,6 +117,8 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
     request.failureBlock = failure;
     
     return request;
+    
+    
 }
 
 #pragma mark - Authorize
@@ -123,7 +134,7 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
     [WeiboSDK sendRequest:self.authorizeRequest];
     
     return self.authorizeRequest;
-
+    
 }
 
 
@@ -235,7 +246,7 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
                                 failure(error);
                             }
                         }];
-
+    
     
 }
 
@@ -267,7 +278,7 @@ static NSString *const kWeiboExpirationDate = @"kWeiboExpirationDate";
                                 failure(error);
                             }
                         }];
-
+    
 }
 
 @end

--- a/v2ex-iOS/v2ex-iOS-Info.plist
+++ b/v2ex-iOS/v2ex-iOS-Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>sinaweibohd</string>
+		<string>sinaweibo</string>
+		<string>weibosdk2.5</string>
+		<string>weibosdk</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
增加了微博的 schemes 方便 SSO 打开微博客户端进行认证。
在 Base request 中增加了对 token 有效性的检查，并能够发起认证请求。
但是不太清楚怎么做认证等待比较好，一方面要立刻返回一个 request，另外一方面 request 又会是在认证的异步回调里才能得到。
想用 dispatch_group 好像又不优雅。

把 project.pbxproj 的改动也带上来了，下次我记得忽略它，抱歉。